### PR TITLE
Fixing raw lua code in fidget.nix

### DIFF
--- a/config/conform.nix
+++ b/config/conform.nix
@@ -6,22 +6,23 @@
         lspFallback = true;
         timeoutMs = 500;
       };
-    };
-    notifyOnError = true;
-    formattersByFt = {
-      html = [["prettierd" "prettier"]];
-      css = [["prettierd" "prettier"]];
-      javascript = [["prettierd" "prettier"]];
-      javascriptreact = [["prettierd" "prettier"]];
-      typescript = [["prettierd" "prettier"]];
-      typescriptreact = [["prettierd" "prettier"]];
-      json = [["prettierd"]];
-      yaml = [["prettierd"]];
-      python = ["black"];
-      lua = ["stylua"];
-      nix = ["alejandra"];
-      markdown = [["prettierd" "prettier"]];
-      rust = ["rustfmt"];
+
+      formatters-by-ft = {
+        html = [["prettierd" "prettier"]];
+        css = [["prettierd" "prettier"]];
+        javascript = [["prettierd" "prettier"]];
+        javascriptreact = [["prettierd" "prettier"]];
+        typescript = [["prettierd" "prettier"]];
+        typescriptreact = [["prettierd" "prettier"]];
+        json = [["prettierd"]];
+        yaml = [["prettierd"]];
+        python = ["black"];
+        lua = ["stylua"];
+        nix = ["alejandra"];
+        markdown = [["prettierd" "prettier"]];
+        rust = ["rustfmt"];
+      };
+      notify-on-error = true;
     };
   };
   extraPackages = with pkgs; [

--- a/config/dap.nix
+++ b/config/dap.nix
@@ -1,0 +1,85 @@
+{
+  config,
+  lib,
+  ...
+}: {
+  plugins.dap = {
+    enable = true;
+    configurations = {
+    };
+  };
+
+  # Optional: UI for DAP
+  plugins.dap-ui.enable = true;
+
+  plugins.dap-go = {
+    enable = true;
+    autoLoad = true;
+  };
+
+  keymaps = [
+    {
+      mode = "n";
+      key = "<F5>";
+      action = ":lua require'dap'.continue()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP: Start/Continue";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F10>";
+      action = ":lua require'dap'.step_over()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP: Step Over";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F11>";
+      action = ":lua require'dap'.step_into()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP: Step Into";
+      };
+    }
+    {
+      mode = "n";
+      key = "<F12>";
+      action = ":lua require'dap'.step_out()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP: Step Out";
+      };
+    }
+    {
+      mode = "n";
+      key = "<Leader>b";
+      action = ":lua require'dap'.toggle_breakpoint()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP: Toggle Breakpoint";
+      };
+    }
+    {
+      mode = "n";
+      key = "<Leader>dt";
+      action = ":lua require('dap-go').debug_test()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP-Go: Debug Test";
+      };
+    }
+    {
+      mode = "n";
+      key = "<Leader>du";
+      action = ":lua require'dapui'.toggle()<CR>";
+      options = {
+        silent = true;
+        desc = "DAP-UI: Toggle";
+      };
+    }
+  ];
+}

--- a/config/default.nix
+++ b/config/default.nix
@@ -14,7 +14,7 @@
     ./comment.nix
     ./conform.nix
     ./lsp.nix
-    ./tmux-navigator.nix
+    #./tmux-navigator.nix
     ./fidget.nix
     ./extraConfig.nix
     ./surround.nix

--- a/config/default.nix
+++ b/config/default.nix
@@ -21,5 +21,7 @@
     ./gitsigns.nix
     ./alpha.nix
     ./keymaps.nix
+
+    ./dap.nix
   ];
 }

--- a/config/fidget.nix
+++ b/config/fidget.nix
@@ -5,96 +5,98 @@
 }: {
   plugins.fidget = {
     enable = true;
-    logger = {
-      level = "warn"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
-      floatPrecision = 0.01; # Limit the number of decimals displayed for floats
-    };
-    progress = {
-      pollRate = 0; # How and when to poll for progress messages
-      suppressOnInsert = true; # Suppress new messages while in insert mode
-      ignoreDoneAlready = false; # Ignore new tasks that are already complete
-      ignoreEmptyMessage = false; # Ignore new tasks that don't contain a message
-      clearOnDetach =
-        # Clear notification group when LSP server detaches
-        ''
-          function(client_id)
-            local client = vim.lsp.get_client_by_id(client_id)
-            return client and client.name or nil
+    settings = {
+      logger = {
+        level = "warn"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
+        floatPrecision = 0.01; # Limit the number of decimals displayed for floats
+      };
+      notification = {
+        pollRate = 10; # How frequently to update and render notifications
+        filter = "info"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
+        historySize = 128; # Number of removed messages to retain in history
+        overrideVimNotify = true;
+        redirect = lib.nixvim.mkRaw ''
+          function(msg, level, opts)
+            if opts and opts.on_open then
+              return require("fidget.integration.nvim-notify").delegate(msg, level, opts)
+            end
           end
         '';
-      notificationGroup =
-        # How to get a progress message's notification group key
-        ''
-          function(msg) return msg.lsp_client.name end
-        '';
-      ignore = []; # List of LSP servers to ignore
-      lsp = {
-        progressRingbufSize = 0; # Configure the nvim's LSP progress ring buffer size
-      };
-      display = {
-        renderLimit = 16; # How many LSP messages to show at once
-        doneTtl = 3; # How long a message should persist after completion
-        doneIcon = "✔"; # Icon shown when all LSP progress tasks are complete
-        doneStyle = "Constant"; # Highlight group for completed LSP tasks
-        progressTtl = lib.nixvim.mkRaw "math.huge"; # How long a message should persist when in progress
-        progressIcon = {
-          pattern = "dots";
-          period = 1;
-        }; # Icon shown when LSP progress tasks are in progress
-        progressStyle = "WarningMsg"; # Highlight group for in-progress LSP tasks
-        groupStyle = "Title"; # Highlight group for group name (LSP server name)
-        iconStyle = "Question"; # Highlight group for group icons
-        priority = 30; # Ordering priority for LSP notification group
-        skipHistory = true; # Whether progress notifications should be omitted from history
-        formatMessage = lib.nixvim.mkRaw ''
-          require ("fidget.progress.display").default_format_message
-        ''; # How to format a progress message
-        formatAnnote = lib.nixvim.mkRaw ''
-          function (msg) return msg.title end
-        ''; # How to format a progress annotation
-        formatGroupName = lib.nixvim.mkRaw ''
-          function (group) return tostring (group) end
-        ''; # How to format a progress notification group's name
-        overrides = {
-          rust_analyzer = {
-            name = "rust-analyzer";
-          };
-        }; # Override options from the default notification config
-      };
-    };
-    notification = {
-      pollRate = 10; # How frequently to update and render notifications
-      filter = "info"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
-      historySize = 128; # Number of removed messages to retain in history
-      overrideVimNotify = true;
-      redirect = lib.nixvim.mkRaw ''
-        function(msg, level, opts)
-          if opts and opts.on_open then
-            return require("fidget.integration.nvim-notify").delegate(msg, level, opts)
-          end
-        end
-      '';
-      configs.default = lib.nixvim.mkRaw "require('fidget.notification').default_config";
+        configs.default = lib.nixvim.mkRaw "require('fidget.notification').default_config";
 
-      window = {
-        normalHl = "Comment";
-        winblend = 0;
-        border = "none"; # none, single, double, rounded, solid, shadow
-        zindex = 45;
-        maxWidth = 0;
-        maxHeight = 0;
-        xPadding = 1;
-        yPadding = 0;
-        align = "bottom";
-        relative = "editor";
+        window = {
+          normalHl = "Comment";
+          winblend = 0;
+          border = "none"; # none, single, double, rounded, solid, shadow
+          zindex = 45;
+          maxWidth = 0;
+          maxHeight = 0;
+          xPadding = 1;
+          yPadding = 0;
+          align = "bottom";
+          relative = "editor";
+        };
+        view = {
+          stackUpwards = true; # Display notification items from bottom to top
+          iconSeparator = " "; # Separator between group name and icon
+          groupSeparator = "---"; # Separator between notification groups
+          groupSeparatorHl =
+            # Highlight group used for group separator
+            "Comment";
+        };
       };
-      view = {
-        stackUpwards = true; # Display notification items from bottom to top
-        iconSeparator = " "; # Separator between group name and icon
-        groupSeparator = "---"; # Separator between notification groups
-        groupSeparatorHl =
-          # Highlight group used for group separator
-          "Comment";
+      progress = {
+        pollRate = 0; # How and when to poll for progress messages
+        suppressOnInsert = true; # Suppress new messages while in insert mode
+        ignoreDoneAlready = false; # Ignore new tasks that are already complete
+        ignoreEmptyMessage = false; # Ignore new tasks that don't contain a message
+        clearOnDetach =
+          # Clear notification group when LSP server detaches
+          ''
+            function(client_id)
+              local client = vim.lsp.get_client_by_id(client_id)
+              return client and client.name or nil
+            end
+          '';
+        notificationGroup =
+          # How to get a progress message's notification group key
+          ''
+            function(msg) return msg.lsp_client.name end
+          '';
+        ignore = []; # List of LSP servers to ignore
+        lsp = {
+          progress_ringbuf_size = 0; # Configure the nvim's LSP progress ring buffer size
+        };
+        display = {
+          renderLimit = 16; # How many LSP messages to show at once
+          doneTtl = 3; # How long a message should persist after completion
+          doneIcon = "✔"; # Icon shown when all LSP progress tasks are complete
+          doneStyle = "Constant"; # Highlight group for completed LSP tasks
+          progressTtl = lib.nixvim.mkRaw "math.huge"; # How long a message should persist when in progress
+          progressIcon = {
+            pattern = "dots";
+            period = 1;
+          }; # Icon shown when LSP progress tasks are in progress
+          progressStyle = "WarningMsg"; # Highlight group for in-progress LSP tasks
+          groupStyle = "Title"; # Highlight group for group name (LSP server name)
+          iconStyle = "Question"; # Highlight group for group icons
+          priority = 30; # Ordering priority for LSP notification group
+          skipHistory = true; # Whether progress notifications should be omitted from history
+          formatMessage = lib.nixvim.mkRaw ''
+            require ("fidget.progress.display").default_format_message
+          ''; # How to format a progress message
+          formatAnnote = lib.nixvim.mkRaw ''
+            function (msg) return msg.title end
+          ''; # How to format a progress annotation
+          formatGroupName = lib.nixvim.mkRaw ''
+            function (group) return tostring (group) end
+          ''; # How to format a progress notification group's name
+          overrides = {
+            rust_analyzer = {
+              name = "rust-analyzer";
+            };
+          }; # Override options from the default notification config
+        };
       };
     };
   };

--- a/config/fidget.nix
+++ b/config/fidget.nix
@@ -1,4 +1,8 @@
 {
+  config,
+  lib,
+  ...
+}: {
   plugins.fidget = {
     enable = true;
     logger = {
@@ -32,7 +36,7 @@
         doneTtl = 3; # How long a message should persist after completion
         doneIcon = "✔"; # Icon shown when all LSP progress tasks are complete
         doneStyle = "Constant"; # Highlight group for completed LSP tasks
-        progressTtl = "math.huge"; # How long a message should persist when in progress
+        progressTtl = lib.nixvim.mkRaw "math.huge"; # How long a message should persist when in progress
         progressIcon = {
           pattern = "dots";
           period = 1;
@@ -42,13 +46,13 @@
         iconStyle = "Question"; # Highlight group for group icons
         priority = 30; # Ordering priority for LSP notification group
         skipHistory = true; # Whether progress notifications should be omitted from history
-        formatMessage = ''
+        formatMessage = lib.nixvim.mkRaw ''
           require ("fidget.progress.display").default_format_message
         ''; # How to format a progress message
-        formatAnnote = ''
+        formatAnnote = lib.nixvim.mkRaw ''
           function (msg) return msg.title end
         ''; # How to format a progress annotation
-        formatGroupName = ''
+        formatGroupName = lib.nixvim.mkRaw ''
           function (group) return tostring (group) end
         ''; # How to format a progress notification group's name
         overrides = {
@@ -63,16 +67,14 @@
       filter = "info"; # “off”, “error”, “warn”, “info”, “debug”, “trace”
       historySize = 128; # Number of removed messages to retain in history
       overrideVimNotify = true;
-      redirect = ''
+      redirect = lib.nixvim.mkRaw ''
         function(msg, level, opts)
           if opts and opts.on_open then
             return require("fidget.integration.nvim-notify").delegate(msg, level, opts)
           end
         end
       '';
-      configs = {
-        default = "require('fidget.notification').default_config";
-      };
+      configs.default = lib.nixvim.mkRaw "require('fidget.notification').default_config";
 
       window = {
         normalHl = "Comment";

--- a/config/lsp.nix
+++ b/config/lsp.nix
@@ -1,9 +1,9 @@
 {pkgs, ...}: {
+  diagnostic.settings.virtual_lines.only_current_line = true;
   plugins = {
     lsp-format = {enable = true;};
     lsp-lines = {
       enable = true;
-      currentLine = true;
     };
     lsp = {
       enable = true;
@@ -33,7 +33,7 @@
         html = {enable = true;};
         lua_ls = {enable = true;};
         nil_ls = {enable = true;};
-        marksman = {enable = true;};
+        #marksman = {enable = true;};
         pyright = {enable = true;};
         lemminx = {enable = true;};
         svelte = {enable = true;};

--- a/config/telescope.nix
+++ b/config/telescope.nix
@@ -14,4 +14,5 @@
   extraPlugins = with pkgs; [
     vimPlugins.nvim-web-devicons
   ];
+  plugins.web-devicons.enable = true;
 }

--- a/config/tmux-navigator.nix
+++ b/config/tmux-navigator.nix
@@ -1,10 +1,10 @@
-{
+{pkgs, ...}: {
   plugins = {
     tmux-navigator = {
       enable = true;
 
       settings = {
-        no_wrap = true;
+        no_wrap = 1;
         disable_when_zoomed = true;
       };
     };

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -26,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743550720,
-        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "lastModified": 1749398372,
+        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
         "type": "github"
       },
       "original": {
@@ -71,27 +71,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1737371634,
-        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
+        "lastModified": 1748294338,
+        "narHash": "sha256-FVO01jdmUNArzBS7NmaktLdGA5qA3lUMJ4B7a05Iynw=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
+        "rev": "cc5f390f7caf265461d4aab37e98d2292ebbdb85",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.7",
+        "ref": "v0.0.8",
         "repo": "ixx",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1747744144,
-        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "lastModified": 1750506804,
+        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
         "type": "github"
       },
       "original": {
@@ -103,11 +103,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "lastModified": 1748740939,
+        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
         "type": "github"
       },
       "original": {
@@ -118,11 +118,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1747920628,
-        "narHash": "sha256-IlAuXnIi+ZmyS89tt1YOFDCv7FKs9bNBHd3MXMp8PxE=",
+        "lastModified": 1750605355,
+        "narHash": "sha256-xT8cPLTxlktxI9vSdoBlAVK7dXgd8IK59j7ZwzkkhnI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e314d5c6d3b3a0f40ec5bcbc007b0cbe412f48ae",
+        "rev": "3078b9a9e75f1790e6d6ef9955fdc6a2d1740cc6",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1748003861,
-        "narHash": "sha256-52csJsvCxH/2iUvwuWXbbk1SHnZMuZ4VRs9K9gvs9nU=",
+        "lastModified": 1750751277,
+        "narHash": "sha256-wdUjRFiiHK8sDmntP1wLYZEqKgju8bGedwulu+myD6E=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "73c1a755f0ac6d09d312daffd13c1ce6572d6fe5",
+        "rev": "3843b6226193bd2c40de0aea1343065b1bf9d3e4",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745046075,
-        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
+        "lastModified": 1749730855,
+        "narHash": "sha256-L3x2nSlFkXkM6tQPLJP3oCBMIsRifhIDPMQQdHO5xWo=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "066afe8643274470f4a294442aadd988356a478f",
+        "rev": "8dfe5879dd009ff4742b668d9c699bc4b9761742",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,50 +1,15 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -61,11 +26,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -92,79 +57,6 @@
         "type": "github"
       }
     },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": [
-          "nixvim",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1734279981,
-        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1734093295,
-        "narHash": "sha256-hSwgGpcZtdDsk1dnzA0xj5cNaHgN9A99hRF/mxMtwS4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "66c5d8b62818ec4c1edb3e941f55ef78df8141a8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "ixx": {
       "inputs": {
         "flake-utils": [
@@ -179,48 +71,27 @@
         ]
       },
       "locked": {
-        "lastModified": 1729958008,
-        "narHash": "sha256-EiOq8jF4Z/zQe0QYVc3+qSKxRK//CFHMB84aYrYGwEs=",
+        "lastModified": 1737371634,
+        "narHash": "sha256-fTVAWzT1UMm1lT+YxHuVPtH+DATrhYfea3B0MxG/cGw=",
         "owner": "NuschtOS",
         "repo": "ixx",
-        "rev": "9fd01aad037f345350eab2cd45e1946cc66da4eb",
+        "rev": "a1176e2a10ce745ff8f63e4af124ece8fe0b1648",
         "type": "github"
       },
       "original": {
         "owner": "NuschtOS",
-        "ref": "v0.0.6",
+        "ref": "v0.0.7",
         "repo": "ixx",
-        "type": "github"
-      }
-    },
-    "nix-darwin": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733570843,
-        "narHash": "sha256-sQJAxY1TYWD1UyibN/FnN97paTFuwBw3Vp3DNCyKsMk=",
-        "owner": "lnl7",
-        "repo": "nix-darwin",
-        "rev": "a35b08d09efda83625bef267eb24347b446c80b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lnl7",
-        "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
         "type": "github"
       },
       "original": {
@@ -232,50 +103,48 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1733096140,
-        "narHash": "sha256-1qRH7uAUsyQI7R1Uwl4T+XvdNv778H0Nb5njNrqvylY=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/5487e69da40cbd611ab2cadee0b4637225f7cfae.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1747920628,
+        "narHash": "sha256-IlAuXnIi+ZmyS89tt1YOFDCv7FKs9bNBHd3MXMp8PxE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "e314d5c6d3b3a0f40ec5bcbc007b0cbe412f48ae",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixvim": {
       "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat",
         "flake-parts": "flake-parts_2",
-        "git-hooks": "git-hooks",
-        "home-manager": "home-manager",
-        "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs_2",
         "nuschtosSearch": "nuschtosSearch",
-        "treefmt-nix": "treefmt-nix"
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1734368549,
-        "narHash": "sha256-D8LYUU+IWbpmyjOAKEnKVOhd7Qfe7q+DvUNZTYoitKY=",
+        "lastModified": 1748003861,
+        "narHash": "sha256-52csJsvCxH/2iUvwuWXbbk1SHnZMuZ4VRs9K9gvs9nU=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "6c30476a4d5f761149945a65e74179f4492b1ea6",
+        "rev": "73c1a755f0ac6d09d312daffd13c1ce6572d6fe5",
         "type": "github"
       },
       "original": {
@@ -294,11 +163,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733773348,
-        "narHash": "sha256-Y47y+LesOCkJaLvj+dI/Oa6FAKj/T9sKVKDXLNsViPw=",
+        "lastModified": 1745046075,
+        "narHash": "sha256-8v4y6k16Ra/fiecb4DxhsoOGtzLKgKlS+9/XJ9z0T2I=",
         "owner": "NuschtOS",
         "repo": "search",
-        "rev": "3051be7f403bff1d1d380e4612f0c70675b44fc9",
+        "rev": "066afe8643274470f4a294442aadd988356a478f",
         "type": "github"
       },
       "original": {
@@ -329,24 +198,18 @@
         "type": "github"
       }
     },
-    "treefmt-nix": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim",
-          "nixpkgs"
-        ]
-      },
+    "systems_2": {
       "locked": {
-        "lastModified": 1733761991,
-        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,12 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
-  outputs =
-    { nixvim, flake-parts, ... }@inputs:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+  outputs = {
+    nixvim,
+    flake-parts,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       systems = [
         "x86_64-linux"
         "aarch64-linux"
@@ -17,31 +20,32 @@
         "aarch64-darwin"
       ];
 
-      perSystem =
-        { pkgs, system, ... }:
-        let
-          nixvimLib = nixvim.lib.${system};
-          nixvim' = nixvim.legacyPackages.${system};
-          nixvimModule = {
-            inherit pkgs;
-            module = import ./config; # import the module directly
-            # You can use `extraSpecialArgs` to pass additional arguments to your module files
-            extraSpecialArgs = {
-              # inherit (inputs) foo;
-            };
-          };
-          nvim = nixvim'.makeNixvimWithModule nixvimModule;
-        in
-        {
-          checks = {
-            # Run `nix flake check .` to verify that your config is not broken
-            default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModule;
-          };
-
-          packages = {
-            # Lets you run `nix run .` to start nixvim
-            default = nvim;
+      perSystem = {
+        pkgs,
+        system,
+        ...
+      }: let
+        nixvimLib = nixvim.lib.${system};
+        nixvim' = nixvim.legacyPackages.${system};
+        nixvimModule = {
+          inherit pkgs;
+          module = import ./config; # import the module directly
+          # You can use `extraSpecialArgs` to pass additional arguments to your module files
+          extraSpecialArgs = {
+            # inherit (inputs) foo;
           };
         };
+        nvim = nixvim'.makeNixvimWithModule nixvimModule;
+      in {
+        checks = {
+          # Run `nix flake check .` to verify that your config is not broken
+          default = nixvimLib.check.mkTestDerivationFromNixvimModule nixvimModule;
+        };
+
+        packages = {
+          # Lets you run `nix run .` to start nixvim
+          default = nvim;
+        };
+      };
     };
 }


### PR DESCRIPTION
After running  I ran into multiple exceptions when building. 

```
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'nixvim'
         whose name attribute is located at /nix/store/p893dkrzm5rxvhnqh092prgi1a7dzmcy-source/pkgs/stdenv/generic/make-derivation.nix:480:13

       … while evaluating attribute 'paths' of derivation 'nixvim'

         at /nix/store/p893dkrzm5rxvhnqh092prgi1a7dzmcy-source/pkgs/build-support/trivial-builders/default.nix:619:11:

          618|           inherit preferLocalBuild allowSubstitutes;
          619|           paths = mapPaths (path: "${path}${stripPrefix}") paths;
             |           ^
          620|           passAsFile = [ "paths" ];

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: A definition for option `plugins.fidget.settings.notification.configs.default' is not of type `raw lua code or (attribute set of anything) or raw lua code'. Definition values:
       - In `/nix/store/6a8j2ywydlrdv9mk4qcmrc6jaw3j384i-source/plugins/by-name/fidget': "require(\"fidget.notification\").default_config"
```

Turns out using lib.nixvim.mkRaw before the lua string fixes this.